### PR TITLE
Update ExternalPostSender.php

### DIFF
--- a/lib/ExternalPostSender.php
+++ b/lib/ExternalPostSender.php
@@ -279,7 +279,7 @@ class ExternalPostSender extends Sender
             'type' => 'textarea',
             'buttons' => false,
             'size' => 'small',
-            'maxlength' => 500,
+            'maxlength' => (int) option('mauricerenck.indieConnector.mastodon.text-length', option('mauricerenck.indieConnector.mastodon-text-length', 500)),
             'required' => true,
         ];
 


### PR DESCRIPTION
shouldn’t the share dialogue be able to set limits for both mastodon and bluesky according to the settings — instead of setting one value for both?